### PR TITLE
feat: add asyncio support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 pytest = "==8.4.1"
-pytest-asyncio = "*"
+pytest-asyncio = "==1.1.0"
 port-for = "==0.7.4"
 mirakuru = "==2.6.1"
 redis = "==6.4.0"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pytest = "==8.4.1"
+pytest = "==8.4.2"
 pytest-asyncio = "==1.1.0"
 port-for = "==0.7.4"
 mirakuru = "==2.6.1"

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 pytest = "==8.4.1"
+pytest-asyncio = "*"
 port-for = "==0.7.4"
 mirakuru = "==2.6.1"
 redis = "==6.4.0"

--- a/newsfragments/852.feature.rst
+++ b/newsfragments/852.feature.rst
@@ -1,0 +1,1 @@
+Add support for asynchronous Redis client

--- a/pytest_redis/factories/__init__.py
+++ b/pytest_redis/factories/__init__.py
@@ -1,7 +1,8 @@
 """Redis fixture factories."""
 
 from pytest_redis.factories.client import redisdb
+from pytest_redis.factories.client_async import redisdb_async
 from pytest_redis.factories.noproc import redis_noproc
 from pytest_redis.factories.proc import redis_proc
 
-__all__ = ("redis_proc", "redis_noproc", "redisdb")
+__all__ = ("redis_proc", "redis_noproc", "redisdb", "redisdb_async")

--- a/pytest_redis/factories/client_async.py
+++ b/pytest_redis/factories/client_async.py
@@ -1,0 +1,65 @@
+"""Redis async client fixture factory."""
+
+from typing import Callable, Generator, Literal, Optional, Union
+
+import pytest
+import redis.asyncio import Redis
+from _pytest.fixtures import FixtureRequest
+
+from pytest_redis.config import get_config
+from pytest_redis.executor import NoopRedis, RedisExecutor
+
+
+def async_redisdb(
+    process_fixture_name: str, dbnum: int = 0, decode: Optional[bool] = None
+) -> Callable[[FixtureRequest], Generator[redis.Redis, None, None]]:
+    """Create connection fixture factory for pytest-redis.
+
+    :param process_fixture_name: name of the process fixture
+    :param dbnum: number of database to use
+    :param decode: Client: to decode response or not.
+        See redis.StrictRedis decode_reponse client parameter.
+    :returns: function which makes a connection to redis
+    """
+
+    @pytest.fixture
+    async def async_redisdb_factory(request: FixtureRequest) -> Generator[redis.Redis, None, None]:
+        """Create connection for pytest-redis.
+
+        #. Load required process fixture.
+        #. Get redis module and config.
+        #. Connect to redis.
+        #. Flush database after tests.
+
+        :param FixtureRequest request: fixture request object
+        :rtype: redis.client.Redis
+        :returns: Redis client
+        """
+        proc_fixture: Union[NoopRedis, RedisExecutor] = request.getfixturevalue(
+            process_fixture_name
+        )
+        config = get_config(request)
+
+        redis_host = proc_fixture.host
+        redis_port = proc_fixture.port
+        redis_username = proc_fixture.username
+        redis_password = proc_fixture.password
+        redis_db = dbnum
+        decode_responses: Union[Literal[True], Literal[False]] = (
+            decode if decode is not None else config["decode"]
+        )
+
+        redis_client = redis.Redis(
+            redis_host,
+            redis_port,
+            redis_db,
+            username=redis_username,
+            password=redis_password,
+            unix_socket_path=proc_fixture.unixsocket,
+            decode_responses=decode_responses,
+        )
+
+        yield redis_client
+        await redis_client.flushall()
+
+    return async_redisdb_factory

--- a/pytest_redis/factories/client_async.py
+++ b/pytest_redis/factories/client_async.py
@@ -3,8 +3,8 @@
 from typing import AsyncGenerator, Callable, Literal, Optional, Union
 
 import pytest
-from redis.asyncio import Redis
 from _pytest.fixtures import FixtureRequest
+from redis.asyncio import Redis
 
 from pytest_redis.config import get_config
 from pytest_redis.executor import NoopRedis, RedisExecutor

--- a/pytest_redis/factories/client_async.py
+++ b/pytest_redis/factories/client_async.py
@@ -12,7 +12,7 @@ from pytest_redis.executor import NoopRedis, RedisExecutor
 
 def redisdb_async(
     process_fixture_name: str, dbnum: int = 0, decode: Optional[bool] = None
-) -> Callable[[FixtureRequest], AsyncGenerator[Redis, None, None]]:
+) -> Callable[[FixtureRequest], AsyncGenerator[Redis]]:
     """Create connection fixture factory for pytest-redis.
 
     :param process_fixture_name: name of the process fixture
@@ -23,7 +23,7 @@ def redisdb_async(
     """
 
     @pytest.fixture
-    async def async_redisdb_factory(request: FixtureRequest) -> AsyncGenerator[Redis, None, None]:
+    async def async_redisdb_factory(request: FixtureRequest) -> AsyncGenerator[Redis]:
         """Create connection for pytest-redis.
 
         #. Load required process fixture.

--- a/pytest_redis/factories/client_async.py
+++ b/pytest_redis/factories/client_async.py
@@ -1,18 +1,18 @@
 """Redis async client fixture factory."""
 
-from typing import Callable, Generator, Literal, Optional, Union
+from typing import AsyncGenerator, Callable, Literal, Optional, Union
 
 import pytest
-import redis.asyncio import Redis
+from redis.asyncio import Redis
 from _pytest.fixtures import FixtureRequest
 
 from pytest_redis.config import get_config
 from pytest_redis.executor import NoopRedis, RedisExecutor
 
 
-def async_redisdb(
+def redisdb_async(
     process_fixture_name: str, dbnum: int = 0, decode: Optional[bool] = None
-) -> Callable[[FixtureRequest], Generator[redis.Redis, None, None]]:
+) -> Callable[[FixtureRequest], AsyncGenerator[Redis, None, None]]:
     """Create connection fixture factory for pytest-redis.
 
     :param process_fixture_name: name of the process fixture
@@ -23,7 +23,7 @@ def async_redisdb(
     """
 
     @pytest.fixture
-    async def async_redisdb_factory(request: FixtureRequest) -> Generator[redis.Redis, None, None]:
+    async def async_redisdb_factory(request: FixtureRequest) -> AsyncGenerator[Redis, None, None]:
         """Create connection for pytest-redis.
 
         #. Load required process fixture.
@@ -49,7 +49,7 @@ def async_redisdb(
             decode if decode is not None else config["decode"]
         )
 
-        redis_client = redis.Redis(
+        redis_client = Redis(
             redis_host,
             redis_port,
             redis_db,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,11 @@ redis_proc3 = pytest_redis.factories.redis_proc(port=6385, password="secretpassw
 redis_nooproc3 = pytest_redis.factories.redis_noproc(port=6385, password="secretpassword")
 
 redisdb2 = pytest_redis.factories.redisdb("redis_proc2")
+redisdb2_async = pytest_redis.factories.redisdb_async("redis_proc2")
 redisdb2_noop = pytest_redis.factories.redisdb("redis_nooproc2")
+redisdb2_noop_async = pytest_redis.factories.redisdb("redis_nooproc2")
 redisdb3 = pytest_redis.factories.redisdb("redis_proc3")
+redisdb3_async = pytest_redis.factories.redisdb_async("redis_proc3")
 redisdb3_noop = pytest_redis.factories.redisdb("redis_nooproc3")
+redisdb3_noop_async = pytest_redis.factories.redisdb("redis_nooproc3")
 # pylint:enable=invalid-name

--- a/tests/test_redis_async.py
+++ b/tests/test_redis_async.py
@@ -1,6 +1,6 @@
 """Module containing all tests for pytest-redis."""
-import pytest
 
+import pytest
 from redis.asyncio import Redis
 
 

--- a/tests/test_redis_async.py
+++ b/tests/test_redis_async.py
@@ -1,0 +1,58 @@
+"""Module containing all tests for pytest-redis."""
+import pytest
+
+from redis.asyncio import Redis
+
+
+@pytest.mark.asyncio
+async def test_redis_async(redisdb_async: Redis) -> None:
+    """Check that it's actually working on redis database using async client."""
+    await redisdb_async.set("test1_async", "test")
+    await redisdb_async.set("test2_async", "test")
+
+    test1 = await redisdb_async.get("test1_async")
+    assert test1 == b"test"
+
+    test2 = await redisdb_async.get("test2_async")
+    assert test2 == b"test"
+
+
+@pytest.mark.asyncio
+async def test_second_redis_async(redisdb_async: Redis, redisdb2_async: Redis) -> None:
+    """Check that two redis prorcesses are separate ones."""
+    await redisdb_async.set("test1_async", "test")
+    await redisdb_async.set("test2_async", "test")
+    await redisdb2_async.set("test1_async", "test_other")
+    await redisdb2_async.set("test2_async", "test_other")
+
+    assert await redisdb_async.get("test1") == b"test"
+    assert await redisdb_async.get("test2") == b"test"
+
+    assert await redisdb2_async.get("test1") == b"test_other"
+    assert await redisdb2_async.get("test2") == b"test_other"
+
+
+@pytest.mark.asyncio
+async def test_external_redis(redisdb2_async: Redis, redisdb2_noop_async: Redis) -> None:
+    """Check that nooproc connects to the same redis."""
+    await redisdb2_async.set("test1", "test_other")
+    await redisdb2_async.set("test2", "test_other")
+
+    assert await redisdb2_async.get("test1") == b"test_other"
+    assert await redisdb2_async.get("test2") == b"test_other"
+
+    assert await redisdb2_noop_async.get("test1") == b"test_other"
+    assert await redisdb2_noop_async.get("test2") == b"test_other"
+
+
+@pytest.mark.asyncio
+async def test_external_redis_auth(redisdb3_async: Redis, redisdb3_noop_async: Redis) -> None:
+    """Check that nooproc connects to the same redis."""
+    await redisdb3_async.set("test1", "test_other")
+    await redisdb3_async.set("test2", "test_other")
+
+    assert await redisdb3_async.get("test1") == b"test_other"
+    assert await redisdb3_async.get("test2") == b"test_other"
+
+    assert await redisdb3_noop_async.get("test1") == b"test_other"
+    assert await redisdb3_noop_async.get("test2") == b"test_other"


### PR DESCRIPTION
Adding a new factory for supporting usage of async Redis client. The PR consists in:

- Adding `pytest-asyncio` dependency for asynchronous support.
- Adding a dedicated factory for async Redis client.
- Adding test to cover async client usage.

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number
