### PR TITLE
Add pyproject-fmt to pre-commit - closes #1019

### DIFF
--- a/.github/ISSUE_TEMPLATE.rst
+++ b/.github/ISSUE_TEMPLATE.rst
@@ -1,7 +1,0 @@
-### What action do you want to perform
-
-
-### What are the results
-
-
-### What are the expected results

--- a/.github/PULL_REQUEST_TEMPLATE.rst
+++ b/.github/PULL_REQUEST_TEMPLATE.rst
@@ -1,5 +1,0 @@
-Chore that needs to be done:
-
-* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`
-
-Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,11 @@ repos:
       - id: rstcheck
         additional_dependencies: [sphinx, toml]
 
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.28.1
+    hooks:
+      - id: pyproject-fmt
+
   - repo: https://github.com/fizyk/pyproject-validator
     rev: v0.1.0
     hooks:

--- a/newsfragments/1019.misc.rst
+++ b/newsfragments/1019.misc.rst
@@ -1,0 +1,1 @@
+Add pyproject-fmt to pre-commit tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,87 +1,131 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools>=61.0.0" ]
+
 [project]
 name = "pytest-redis"
 version = "4.0.0"
 description = "Redis fixtures and fixture factories for Pytest."
 readme = "README.rst"
-keywords = ["tests", "pytest", "fixture", "redis"]
-license = {file = "COPYING.lesser"}
-authors = [
-    {name = "Grzegorz Śliwiński", email = "fizyk+pypi@fizyk.dev"}
-]
+keywords = [ "fixture", "pytest", "redis", "tests" ]
+license = { file = "COPYING.lesser" }
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
+    "Framework :: Pytest",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
-    "Framework :: Pytest",
 ]
 dependencies = [
-    "pytest >= 8.4.0",
-    "port-for >= 0.7.3",
-    "mirakuru >= 2.6.0",
-    "redis >= 4.1.0",
+    "mirakuru>=2.6.0",
+    "port-for>=0.7.3",
+    "pytest>=8.4.0",
+    "redis>=4.1.0",
 ]
-requires-python = ">= 3.10"
+
+[[project.authors]]
+name = "Grzegorz Śliwiński"
+email = "fizyk+pypi@fizyk.dev"
 
 [project.urls]
-"Source" = "https://github.com/dbfixtures/pytest-redis"
+Source = "https://github.com/dbfixtures/pytest-redis"
 "Bug Tracker" = "https://github.com/dbfixtures/pytest-redis/issues"
-"Changelog" = "https://github.com/dbfixtures/pytest-redis/blob/v4.0.0/CHANGES.rst"
+Changelog = "https://github.com/dbfixtures/pytest-redis/blob/v4.0.0/CHANGES.rst"
 
-[project.entry-points."pytest11"]
+[project.entry-points.pytest11]
 pytest_redis = "pytest_redis.plugin"
-
-[build-system]
-requires = ["setuptools >= 61.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 zip-safe = true
 
 [tool.setuptools.packages.find]
-include = ["pytest_redis*"]
-exclude = ["tests*"]
+include = [ "pytest_redis*" ]
+exclude = [ "tests*" ]
 namespaces = false
-
-[tool.pytest]
-xfail_strict=true
-addopts = ["--showlocals", "--verbose"]
-testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 100
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle
-    "F",   # pyflakes
-    "I",   # isort
-    "D",   # pydocstyle
+    "E", # pycodestyle
+    "F", # pyflakes
+    "I", # isort
+    "D", # pydocstyle
 ]
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"
 
-[tool.rstcheck]
-report_level = "warning"
+[tool.pyproject-fmt]
+column_width = 120
+indent = 4
+keep_full_version = true
+generate_python_version_classifiers = false
+table_format = "long"
+sub_table_spacing = "\n"
+
+[tool.pytest]
+addopts = [ "--showlocals", "--verbose" ]
+testpaths = [ "tests" ]
+xfail_strict = true
+
+[tool.tbump]
+
+[[tool.tbump.before_commit]]
+name = "Build changelog"
+cmd = "pipenv run towncrier build --version {new_version} --yes"
+
+[[tool.tbump.field]]
+name = "extra"
+default = ""
+
+[[tool.tbump.file]]
+src = "pytest_redis/__init__.py"
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+search = 'version = "{current_version}"'
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+search = 'Changelog = "https://github.com/dbfixtures/pytest-redis/blob/v{current_version}/CHANGES.rst"'
+
+[tool.tbump.git]
+message_template = "Release {new_version}"
+tag_template = "v{new_version}"
+
+[tool.tbump.version]
+current = "4.0.0"
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (\-
+    (?P<extra>.+)
+  )?
+  '''
 
 [tool.towncrier]
 directory = "newsfragments"
-single_file=true
-filename="CHANGES.rst"
-issue_format="`#{issue} <https://github.com/dbfixtures/pytest-redis/issues/{issue}>`__"
+filename = "CHANGES.rst"
+issue_format = "`#{issue} <https://github.com/dbfixtures/pytest-redis/issues/{issue}>`__"
+single_file = true
 
 [[tool.towncrier.type]]
 directory = "break"
@@ -113,62 +157,5 @@ directory = "misc"
 name = "Miscellaneus"
 showcontent = true
 
-[tool.tbump]
-# Uncomment this if your project is hosted on GitHub:
-# github_url = "https://github.com/dbfixtures/pytest-dynamodb/"
-
-[tool.tbump.version]
-current = "4.0.0"
-
-# Example of a semver regexp.
-# Make sure this matches current_version before
-# using tbump
-regex = '''
-  (?P<major>\d+)
-  \.
-  (?P<minor>\d+)
-  \.
-  (?P<patch>\d+)
-  (\-
-    (?P<extra>.+)
-  )?
-  '''
-
-[tool.tbump.git]
-message_template = "Release {new_version}"
-tag_template = "v{new_version}"
-
-[[tool.tbump.field]]
-# the name of the field
-name = "extra"
-# the default value to use, if there is no match
-default = ""
-
-
-# For each file to patch, add a [[file]] config
-# section containing the path of the file, relative to the
-# tbump.toml location.
-[[tool.tbump.file]]
-src = "pytest_redis/__init__.py"
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-search = 'version = "{current_version}"'
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-search = '"Changelog" = "https://github.com/dbfixtures/pytest-redis/blob/v{current_version}/CHANGES.rst"'
-
-# You can specify a list of commands to
-# run after the files have been patched
-# and before the git commit is made
-
-[[tool.tbump.before_commit]]
-name = "Build changelog"
-cmd = "pipenv run towncrier build --version {new_version} --yes"
-
-# Or run some commands after the git tag and the branch
-# have been pushed:
-#  [[tool.tbump.after_push]]
-#  name = "publish"
-#  cmd = "./publish.sh"
+[tool.rstcheck]
+report_level = "warning"


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated project-metadata formatting to the development workflow.
  * Updated project configuration for consistent formatting and stricter test handling.
* **Documentation**
  * Simplified contribution templates by removing outdated issue and pull-request prompts.
  * Added a changelog entry documenting the new formatting workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->