### PR TITLE
Add Redis 8.8. and 8.10 to testing matrix on CI

### DIFF
--- a/.download-redis.sh
+++ b/.download-redis.sh
@@ -15,10 +15,11 @@ if [ ! -f "$HOME/redis" ]; then
   mkdir $HOME/redis
 fi
 
-download_redis https://download.redis.io/releases/redis-8.6.1.tar.gz 8.6
-download_redis https://download.redis.io/releases/redis-8.4.2.tar.gz 8.4
-download_redis https://download.redis.io/releases/redis-8.2.5.tar.gz 8.2
-download_redis https://download.redis.io/releases/redis-8.0.6.tar.gz 8.0
-download_redis https://download.redis.io/releases/redis-7.4.8.tar.gz 7.4
-download_redis https://download.redis.io/releases/redis-7.2.13.tar.gz 7.2
-download_redis https://download.redis.io/releases/redis-6.2.21.tar.gz 6.2
+download_redis https://download.redis.io/releases/redis-8.10.1.tar.gz 8.10
+download_redis https://download.redis.io/releases/redis-8.8.2.tar.gz 8.8
+download_redis https://download.redis.io/releases/redis-8.6.6.tar.gz 8.6
+download_redis https://download.redis.io/releases/redis-8.4.6.tar.gz 8.4
+download_redis https://download.redis.io/releases/redis-8.2.9.tar.gz 8.2
+download_redis https://download.redis.io/releases/redis-7.4.11.tar.gz 7.4
+download_redis https://download.redis.io/releases/redis-7.2.16.tar.gz 7.2
+download_redis https://download.redis.io/releases/redis-6.2.24.tar.gz 6.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     needs: [download_redis]
     uses: ./.github/workflows/single-redis.yml
     with:
-      redis-versions: '["8.4", "8.6"]'
+      redis-versions: '["8.4", "8.6", "8.10", "8.8"]'
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
   tests_older:

--- a/newsfragments/+418d7483.misc.rst
+++ b/newsfragments/+418d7483.misc.rst
@@ -1,0 +1,1 @@
+Add Redis 8.8 and 8.10 to testing matrix on CI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the available Redis releases, adding versions 8.10.1, 8.8.2 and 8.6.6.
  - Updated Redis 8.4, 8.2, 7.4, 7.2 and 6.2 patch releases.
  - Redis 8.0.6 is no longer included in the downloaded release set.

- **Tests**
  - Expanded automated testing to cover Redis 8.4, 8.6, 8.8 and 8.10.

- **Documentation**
  - Added release notes documenting Redis 8.8 and 8.10 test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->