### PR TITLE
Add Python 3.15 to CI - closes #1021

### DIFF
--- a/.github/workflows/single-redis-oldest.yml
+++ b/.github/workflows/single-redis-oldest.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       python-versions:
         description: 'Supported python versions'
-        default: '["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy-3.11"]'
         required: false
         type: string
       redis-versions:

--- a/.github/workflows/single-redis.yml
+++ b/.github/workflows/single-redis.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       python-versions:
         description: 'Supported python versions'
-        default: '["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy-3.11"]'
         required: false
         type: string
       redis-versions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     needs: [download_redis]
     uses: ./.github/workflows/single-redis.yml
     with:
-      python-versions: '["3.13", "3.14"]'
+      python-versions: '["3.13", "3.14", "3.15"]'
       redis-versions: '["6.2", "7.2", "7.4", "8.2"]'
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
     needs: [download_redis]
     uses: ./.github/workflows/single-redis-oldest.yml
     with:
-      python-versions: '["3.10", "3.14"]'
+      python-versions: '["3.10", "3.14", "3.15"]'
       redis-versions: '["6.2", "7.2", "8.2"]'
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/newsfragments/1021.misc.rst
+++ b/newsfragments/1021.misc.rst
@@ -1,0 +1,1 @@
+Add Python 3.15 to CI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Automated test coverage now includes Python 3.15 across additional supported-version combinations.
  - Compatibility checks continue to cover Python 3.10 through 3.14 and PyPy 3.11.

- **Documentation**
  - Added a release note documenting the expanded Python 3.15 continuous-integration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->