### PR TITLE
Enable ruff FBT ruleset - closes #1022

### DIFF
--- a/newsfragments/1022.break.rst
+++ b/newsfragments/1022.break.rst
@@ -1,0 +1,7 @@
+Boolean parameters are now keyword-only, and so are the parameters that follow them:
+
+* ``RedisExecutor``: ``rdbcompression``, ``rdbchecksum``, ``syslog_enabled``, ``appendonly``,
+  ``datadir`` and ``modules``
+* ``redis_proc``: ``compression``, ``checksum``, ``syslog``, ``loglevel``, ``datadir``
+  and ``modules``
+* ``redisdb`` and ``redisdb_async``: ``decode``

--- a/newsfragments/1022.misc.rst
+++ b/newsfragments/1022.misc.rst
@@ -1,0 +1,1 @@
+Enabled Ruff's `FBT <https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt>`_ rules to detect boolean positional arguments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,10 +83,11 @@ line-length = 100
 
 [tool.ruff.lint]
 select = [
-    "E", # pycodestyle
-    "F", # pyflakes
-    "I", # isort
-    "D", # pydocstyle
+    "E",   # pycodestyle
+    "F",   # pyflakes
+    "I",   # isort
+    "D",   # pydocstyle
+    "FBT", # flake8-boolean-trap
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pytest_redis/executor/process.py
+++ b/pytest_redis/executor/process.py
@@ -53,6 +53,7 @@ class RedisExecutor(TCPExecutor):
         startup_timeout: int = 60,
         save: str = "",
         daemonize: str = "no",
+        *,
         rdbcompression: bool = True,
         rdbchecksum: bool = False,
         syslog_enabled: bool = False,

--- a/pytest_redis/factories/client.py
+++ b/pytest_redis/factories/client.py
@@ -11,7 +11,7 @@ from pytest_redis.executor import NoopRedis, RedisExecutor
 
 
 def redisdb(
-    process_fixture_name: str, dbnum: int = 0, decode: bool | None = None
+    process_fixture_name: str, dbnum: int = 0, *, decode: bool | None = None
 ) -> Callable[[FixtureRequest], Generator[redis.Redis, None, None]]:
     """Create connection fixture factory for pytest-redis.
 

--- a/pytest_redis/factories/client_async.py
+++ b/pytest_redis/factories/client_async.py
@@ -38,7 +38,7 @@ def _unavailable_stub() -> Callable[[pytest.FixtureRequest], AsyncIterator[Redis
 
 
 def redisdb_async(
-    process_fixture_name: str, dbnum: int = 0, decode: bool | None = None
+    process_fixture_name: str, dbnum: int = 0, *, decode: bool | None = None
 ) -> Callable[[pytest.FixtureRequest], AsyncIterator[Redis]]:
     """Create async connection fixture factory for pytest-redis.
 

--- a/pytest_redis/factories/proc.py
+++ b/pytest_redis/factories/proc.py
@@ -31,6 +31,7 @@ def redis_proc(
     password: str | None = None,
     db_count: int | None = None,
     save: str | None = None,
+    *,
     compression: bool | None = None,
     checksum: bool | None = None,
     syslog: bool | None = None,

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -69,7 +69,7 @@ def test_redis_exec_configuration(
     (True, False),
 )
 def test_redis_exec(
-    request: FixtureRequest, tmp_path_factory: TempPathFactory, syslog_enabled: bool
+    request: FixtureRequest, tmp_path_factory: TempPathFactory, *, syslog_enabled: bool
 ) -> None:
     """Check if RedisExecutor properly starts with these configuration options.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Boolean and subsequent optional parameters for Redis process and client helpers must now be supplied by keyword.
  - This applies to `RedisExecutor`, `redis_proc`, `redisdb`, and related interfaces; existing positional calls may need updating.

- **Quality Improvements**
  - Boolean positional-argument patterns are now detected by the project’s linting checks, helping prevent ambiguous API usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->